### PR TITLE
This ensures **only** Markdown images are modified, leaving other `!`…

### DIFF
--- a/app.py
+++ b/app.py
@@ -607,7 +607,7 @@ def messages_prepare(messages: list) -> str:
             parts.append(text)
     final_prompt = "".join(parts)
     # 移除 markdown 图片格式：
-    final_prompt = re.sub(r"!", "", final_prompt)
+    final_prompt = re.sub(r"!\[(.*?)\]\((.*?)\)", r"[\1](\2)", final_prompt)
     return final_prompt
 
 


### PR DESCRIPTION
… characters

To precisely remove only the exclamation mark (`!`) in Markdown image syntax (`![alt](url)`) without affecting other instances of `![`, use this regex pattern:

```python
final_prompt = re.sub(r"!\[(.*?)\]\((.*?)\)", r"[\1](\2)", final_prompt)
```

### Explanation:
- **Pattern:** `!\[(.*?)\]\((.*?)\)`
  - `!\[`: Matches the literal `![` at the start of a Markdown image.
  - `(.*?)`: **Group 1** (non-greedy match) for the alt text between `[` and `]`.
  - `\]\(`: Matches the closing `]` and opening `(` before the URL.
  - `(.*?)`: **Group 2** (non-greedy match) for the URL between `(` and `)`.
- **Replacement:** `[\1](\2)`
  - Reconstructs the Markdown link **without the `!`**, preserving the alt text (`\1`) and URL (`\2`).

### Example:
- Input: `A screenshot: ![image](photo.png) and another ![logo](brand.png)`
- Output: `A screenshot: [image](photo.png) and another [logo](brand.png)`

This ensures **only** Markdown images are modified, leaving other `!` characters (e.g., `Hello! [This is not an image]`) untouched.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

I propose the fix because the signs ! were being removed from the checks if a != b for example

<!-- Add any other context about the Pull Request here. -->